### PR TITLE
Bump isort from 5.13.2 to 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
   # Docformatter 1.7.5 isn't compatible with Pre-commit 4.0


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.13.2 to 6.0.0 and ran the update against the repo.