### PR TITLE
Bump isort from 8.0.1 to 9.0.0a3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
+    rev: 9.0.0a3
     hooks:
       - id: isort
   # Docformatter 1.7.5 isn't compatible with Pre-commit 4.0


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 8.0.1 to 9.0.0a3 and ran the update against the repo.